### PR TITLE
Add attribute force to ensure test fails loudly

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,6 +1,7 @@
 Revision history for Dist-Zilla-Plugin-AuthorSignatureTest
 
 {{$NEXT}}
+    - Add attribute force to make test fail also when not able to perform it
 
 0.02  2017-07-31
     - add MANIFEST.SKIP

--- a/dist.ini
+++ b/dist.ini
@@ -7,3 +7,6 @@ copyright_year = 2017
 [@MSCHOUT]
 use_travis = 1
 use_twitter = 1
+
+[Meta::Contributors]
+contributor = Mikko Koivunalho <mikkoi@cpan.org>

--- a/lib/Dist/Zilla/Plugin/AuthorSignatureTest.pm
+++ b/lib/Dist/Zilla/Plugin/AuthorSignatureTest.pm
@@ -29,7 +29,7 @@ has force => (
 
 =head1 DESCRIPTION
 
-This is an extensionof L<Dist::Zilla::Plugin::InlineFile>, providing the
+This is an extension of L<Dist::Zilla::Plugin::InlineFile>, providing the
 following files:
 
    xt/author/signature.t - a standard Test::Signature test

--- a/lib/Dist/Zilla/Plugin/AuthorSignatureTest.pm
+++ b/lib/Dist/Zilla/Plugin/AuthorSignatureTest.pm
@@ -9,7 +9,23 @@ use warnings;
 use Moose;
 
 extends 'Dist::Zilla::Plugin::InlineFiles';
-with 'Dist::Zilla::Role::PrereqSource';
+with (
+    'Dist::Zilla::Role::PrereqSource',
+    'Dist::Zilla::Role::FileMunger',
+    'Dist::Zilla::Role::TextTemplate',
+);
+
+has force => (
+        is       => 'ro',
+        isa      => 'Bool',
+        default  => sub { 0; },
+);
+
+=head1 SYNOPSIS
+
+   [AuthorSignatureTest]
+   force = false
+
 
 =head1 DESCRIPTION
 
@@ -21,16 +37,44 @@ following files:
 This test uses L<Test::Signature> to test the SIGNATURE file in your dist.  If
 L<Test::Signature> is not installed, the test is skipped.
 
+
+=head1 ATTRIBUTES
+
+=head2 force
+
+E.g. C<force = true>
+
+By default L<Test::Signature>::signature_ok does not make test fail if it cannot perform it,
+for example, because of missing B<SIGNATURE> file, missing package L<Module::Signature>
+or not able to make connection to the key server.
+
+Turn on this feature to make test fail also in the above cases.
+
+
 =for Pod::Coverage register_prereqs
 
 =cut
 
 sub register_prereqs {
     my $self = shift;
-
     $self->zilla->register_prereqs(
         { type => 'requires', phase => 'develop' },
         'Test::Signature' => 0);
+}
+
+sub munge_file {
+    my $self = shift;
+    my ($file) = @_;
+
+    return unless $file->name eq 'xt/author/signature.t';
+    $file->content(
+        $self->fill_in_string(
+            $file->content,
+            {
+                force => $self->force ? q{force_} : q{},
+            }
+        )
+    );
 }
 
 __PACKAGE__->meta->make_immutable;
@@ -49,5 +93,5 @@ unless (eval { require Test::Signature; 1 }) {
     plan skip_all => 'Test::Signature is required for this test';
 }
 
-Test::Signature::signature_ok();
+Test::Signature::signature_{{ $force ? 'force_' : '' }}ok();
 done_testing;

--- a/t/attribute-force.t
+++ b/t/attribute-force.t
@@ -1,0 +1,95 @@
+#!perl
+
+use strict;
+use warnings;
+use Test::More 0.88;
+use Test::Deep;
+
+use Test::DZil;
+
+
+my $tzil = Builder->from_config(
+    { dist_root => 'corpus/dist/DZT' },
+    {
+        add_files => {
+            'source/dist.ini' => simple_ini(
+                ['GatherDir'],
+                ['AuthorSignatureTest' => {
+                    force => '1',
+                  }
+                ]
+            )
+        }
+    }
+);
+
+$tzil->build;
+
+cmp_deeply(
+    $tzil->distmeta,
+    superhashof(
+        {
+            prereqs => {
+                develop => {
+                    requires => {
+                        'Test::Signature' => 0
+                    }
+                }
+            }
+        }
+    ),
+    'Test::Signature develop prereqs'
+);
+
+like $tzil->slurp_file('build/xt/author/signature.t'),
+    qr/\Qrequire Test::Signature/,
+    'xt/author/signature.t content';
+
+like $tzil->slurp_file('build/xt/author/signature.t'),
+    qr/\QTest::Signature::signature_force_ok();/,
+    'xt/author/signature.t content';
+
+$tzil = Builder->from_config(
+    { dist_root => 'corpus/dist/DZT' },
+    {
+        add_files => {
+            'source/dist.ini' => simple_ini(
+                ['GatherDir'],
+                ['AuthorSignatureTest' => {
+                    force => '0',
+                  }
+                ]
+            )
+        }
+    }
+);
+
+$tzil->build;
+
+cmp_deeply(
+    $tzil->distmeta,
+    superhashof(
+        {
+            prereqs => {
+                develop => {
+                    requires => {
+                        'Test::Signature' => 0
+                    }
+                }
+            }
+        }
+    ),
+    'Test::Signature develop prereqs'
+);
+
+like $tzil->slurp_file('build/xt/author/signature.t'),
+    qr/\Qrequire Test::Signature/,
+    'xt/author/signature.t content';
+
+like $tzil->slurp_file('build/xt/author/signature.t'),
+    qr/\QTest::Signature::signature_ok();/,
+    'xt/author/signature.t content';
+
+
+done_testing;
+


### PR DESCRIPTION
By default Test::Signature::signature_ok() does not make test fail if it cannot perform it,
for example, because of missing **SIGNATURE** file, missing package **Module::Signature**
or not able to make connection to the key server.
Turn on this feature to make test fail also in the above cases.